### PR TITLE
fix: guard OpenApiClient config property reads for PHP 8+

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,120 @@
+name: PHP CI
+
+on:
+  push:
+    branches: [ master, main ]
+
+  pull_request:
+    branches: [ master, main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mbstring, intl, json
+        ini-values: post_max_size=256M, max_execution_time=180
+        coverage: none
+        tools: composer:v2
+
+    - name: Validate composer.json
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ matrix.php-versions }}-
+
+    - name: Install dependencies
+      run: |
+        if php -r 'exit(version_compare(PHP_VERSION, "7.2.0", "<") ? 0 : 1);'; then
+          composer require --dev phpunit/phpunit:^5.7.27 --no-update
+        elif php -r 'exit(version_compare(PHP_VERSION, "7.3.0", "<") ? 0 : 1);'; then
+          composer require --dev phpunit/phpunit:^8.5.28 --no-update
+        else
+          composer require --dev phpunit/phpunit:^9.6.19 --no-update
+        fi
+        # guzzlehttp/psr7 >= 2.7 tightened Uri::validateHost() and now rejects
+        # "host:port" strings that alibabacloud/darabonba (Request.php:82) still
+        # feeds into Uri::withHost(), breaking every test that points at a local
+        # mock server (e.g. 127.0.0.1:8000). Pin <2.7 here without touching the
+        # committed composer.json. PHP 5.6/7.0/7.1 fall back to psr7 ^1.9 (psr7
+        # v2 needs PHP >=7.2.5).
+        #
+        # Also pin guzzlehttp/guzzle <7.9 because guzzle 7.9+ hard-requires
+        # psr7 ^2.7+, which would defeat the psr7 pin above.
+        #
+        # Composer 2.8+ blocks installs of versions covered by security
+        # advisories. Flip the advisory block ephemerally with jq.
+        jq '.config.policy.advisories.block = false' composer.json > composer.json.tmp \
+          && mv composer.json.tmp composer.json
+        if php -r 'exit(version_compare(PHP_VERSION, "7.2.0", "<") ? 0 : 1);'; then
+          composer require \
+            'guzzlehttp/psr7:1.9.1' \
+            'guzzlehttp/guzzle:6.5.8' \
+            'guzzlehttp/promises:1.5.3' \
+            --no-update
+        else
+          composer require \
+            'guzzlehttp/psr7:^1.9 || >=2.0,<2.7' \
+            'guzzlehttp/guzzle:^6.3 || >=7.0,<7.9' \
+            --no-update
+        fi
+        composer update --prefer-stable --prefer-dist --no-progress --no-interaction
+
+    - name: Run syntax check
+      run: find src tests -name "*.php" -exec php -l {} \;
+
+    - name: Run PHPUnit tests
+      run: composer test:all
+
+  coverage:
+    runs-on: ubuntu-latest
+    name: Code Coverage
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+        extensions: mbstring, intl
+        coverage: xdebug
+
+    - name: Install dependencies
+      run: |
+        composer require --dev phpunit/phpunit:^9.6.19 --no-update
+        jq '.config.policy.advisories.block = false' composer.json > composer.json.tmp \
+          && mv composer.json.tmp composer.json
+        composer require \
+          'guzzlehttp/psr7:^1.9 || >=2.0,<2.7' \
+          'guzzlehttp/guzzle:^6.3 || >=7.0,<7.9' \
+          --no-update
+        composer update --prefer-stable --prefer-dist --no-progress --no-interaction
+
+    - name: Run tests with coverage
+      run: vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/OpenApiClient.php
+++ b/src/OpenApiClient.php
@@ -222,60 +222,70 @@ class OpenApiClient
       ]);
     }
 
-    if ((!is_null($config->accessKeyId) && $config->accessKeyId != '') && (!is_null($config->accessKeySecret) && $config->accessKeySecret != '')) {
-      if (!is_null($config->securityToken) && $config->securityToken != '') {
-        $config->type = 'sts';
+    $accessKeyId = property_exists($config, 'accessKeyId') ? $config->accessKeyId : null;
+    $accessKeySecret = property_exists($config, 'accessKeySecret') ? $config->accessKeySecret : null;
+    $securityToken = property_exists($config, 'securityToken') ? $config->securityToken : null;
+    $bearerToken = property_exists($config, 'bearerToken') ? $config->bearerToken : null;
+    $credential = property_exists($config, 'credential') ? $config->credential : null;
+    $userAgent = property_exists($config, 'userAgent') ? $config->userAgent : null;
+
+    if ((!is_null($accessKeyId) && $accessKeyId != '') && (!is_null($accessKeySecret) && $accessKeySecret != '')) {
+      if (!is_null($securityToken) && $securityToken != '') {
+        $type = 'sts';
       } else {
-        $config->type = 'access_key';
+        $type = 'access_key';
+      }
+      if (property_exists($config, 'type')) {
+        $config->type = $type;
       }
 
       $credentialConfig = new Config([
-        'accessKeyId' => $config->accessKeyId,
-        'type' => $config->type,
-        'accessKeySecret' => $config->accessKeySecret,
+        'accessKeyId' => $accessKeyId,
+        'type' => $type,
+        'accessKeySecret' => $accessKeySecret,
       ]);
-      $credentialConfig->securityToken = $config->securityToken;
+      $credentialConfig->securityToken = $securityToken;
       $this->_credential = new Credential($credentialConfig);
-    } else if (!is_null($config->bearerToken) && $config->bearerToken != '') {
+    } else if (!is_null($bearerToken) && $bearerToken != '') {
       $cc = new Config([
         'type' => 'bearer',
-        'bearerToken' => $config->bearerToken,
+        'bearerToken' => $bearerToken,
       ]);
       $this->_credential = new Credential($cc);
-    } else if (!is_null($config->credential)) {
-      $this->_credential = $config->credential;
+    } else if (!is_null($credential)) {
+      $this->_credential = $credential;
     }
 
-    if (is_null($config->userAgent)) {
+    if (is_null($userAgent)) {
       $this->_userAgent = getenv('ALIBABA_CLOUD_USER_AGENT');
     } else {
-      $this->_userAgent = $config->userAgent;
+      $this->_userAgent = $userAgent;
     }
 
-    $this->_endpoint = $config->endpoint;
-    $this->_endpointType = $config->endpointType;
-    $this->_network = $config->network;
-    $this->_suffix = $config->suffix;
-    $this->_protocol = $config->protocol;
-    $this->_method = $config->method;
-    $this->_regionId = $config->regionId;
-    $this->_readTimeout = $config->readTimeout;
-    $this->_connectTimeout = $config->connectTimeout;
-    $this->_httpProxy = $config->httpProxy;
-    $this->_httpsProxy = $config->httpsProxy;
-    $this->_noProxy = $config->noProxy;
-    $this->_socks5Proxy = $config->socks5Proxy;
-    $this->_socks5NetWork = $config->socks5NetWork;
-    $this->_maxIdleConns = $config->maxIdleConns;
-    $this->_signatureVersion = $config->signatureVersion;
-    $this->_signatureAlgorithm = $config->signatureAlgorithm;
-    $this->_globalParameters = $config->globalParameters;
-    $this->_key = $config->key;
-    $this->_cert = $config->cert;
-    $this->_ca = $config->ca;
-    $this->_disableHttp2 = $config->disableHttp2;
-    $this->_retryOptions = $config->retryOptions;
-    $this->_tlsMinVersion = $config->tlsMinVersion;
+    $this->_endpoint = property_exists($config, 'endpoint') ? $config->endpoint : null;
+    $this->_endpointType = property_exists($config, 'endpointType') ? $config->endpointType : null;
+    $this->_network = property_exists($config, 'network') ? $config->network : null;
+    $this->_suffix = property_exists($config, 'suffix') ? $config->suffix : null;
+    $this->_protocol = property_exists($config, 'protocol') ? $config->protocol : null;
+    $this->_method = property_exists($config, 'method') ? $config->method : null;
+    $this->_regionId = property_exists($config, 'regionId') ? $config->regionId : null;
+    $this->_readTimeout = property_exists($config, 'readTimeout') ? $config->readTimeout : null;
+    $this->_connectTimeout = property_exists($config, 'connectTimeout') ? $config->connectTimeout : null;
+    $this->_httpProxy = property_exists($config, 'httpProxy') ? $config->httpProxy : null;
+    $this->_httpsProxy = property_exists($config, 'httpsProxy') ? $config->httpsProxy : null;
+    $this->_noProxy = property_exists($config, 'noProxy') ? $config->noProxy : null;
+    $this->_socks5Proxy = property_exists($config, 'socks5Proxy') ? $config->socks5Proxy : null;
+    $this->_socks5NetWork = property_exists($config, 'socks5NetWork') ? $config->socks5NetWork : null;
+    $this->_maxIdleConns = property_exists($config, 'maxIdleConns') ? $config->maxIdleConns : null;
+    $this->_signatureVersion = property_exists($config, 'signatureVersion') ? $config->signatureVersion : null;
+    $this->_signatureAlgorithm = property_exists($config, 'signatureAlgorithm') ? $config->signatureAlgorithm : null;
+    $this->_globalParameters = property_exists($config, 'globalParameters') ? $config->globalParameters : null;
+    $this->_key = property_exists($config, 'key') ? $config->key : null;
+    $this->_cert = property_exists($config, 'cert') ? $config->cert : null;
+    $this->_ca = property_exists($config, 'ca') ? $config->ca : null;
+    $this->_disableHttp2 = property_exists($config, 'disableHttp2') ? $config->disableHttp2 : null;
+    $this->_retryOptions = property_exists($config, 'retryOptions') ? $config->retryOptions : null;
+    $this->_tlsMinVersion = property_exists($config, 'tlsMinVersion') ? $config->tlsMinVersion : null;
   }
 
   /**
@@ -1844,7 +1854,9 @@ class OpenApiClient
    */
   public function checkConfig($config)
   {
-    if (is_null($this->_endpointRule) && is_null($config->endpoint)) {
+    if (is_null($this->_endpointRule)
+        && property_exists($config, 'endpoint')
+        && is_null($config->endpoint)) {
       throw new ClientException([
         'code' => 'ParameterMissing',
         'message' => '\'config.endpoint\' can not be empty',

--- a/src/OpenApiClient.php
+++ b/src/OpenApiClient.php
@@ -222,6 +222,8 @@ class OpenApiClient
       ]);
     }
 
+    // PHP 8+ : non-OpenApi Config (e.g. Credential\Config) lacks these fields.
+    // property_exists avoids Undefined property notices. Re-apply after codegen.
     $accessKeyId = property_exists($config, 'accessKeyId') ? $config->accessKeyId : null;
     $accessKeySecret = property_exists($config, 'accessKeySecret') ? $config->accessKeySecret : null;
     $securityToken = property_exists($config, 'securityToken') ? $config->securityToken : null;

--- a/tests/SafeConfigPropertyTest.php
+++ b/tests/SafeConfigPropertyTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Darabonba\OpenApi\Tests;
+
+use AlibabaCloud\Credentials\Credential;
+use AlibabaCloud\Credentials\Credential\Config as CredentialConfig;
+use Darabonba\OpenApi\Exceptions\ClientException;
+use Darabonba\OpenApi\Models\Config;
+use Darabonba\OpenApi\OpenApiClient;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @internal
+ * @covers \Darabonba\OpenApi\OpenApiClient
+ */
+class SafeConfigPropertyTest extends TestCase
+{
+    private function prop($object, $name)
+    {
+        $ref = new ReflectionClass($object);
+        $p = $ref->getProperty($name);
+        $p->setAccessible(true);
+        return $p->getValue($object);
+    }
+
+    public function testConstructWithCredentialConfigEmitsNoUndefinedProperty()
+    {
+        $notices = [];
+        set_error_handler(function ($errno, $errstr) use (&$notices) {
+            if (stripos($errstr, 'Undefined property') !== false) {
+                $notices[] = $errstr;
+            }
+            return true;
+        });
+
+        $credConfig = new CredentialConfig([
+            'type' => 'access_key',
+            'accessKeyId' => 'test-ak',
+            'accessKeySecret' => 'test-sk',
+        ]);
+        $client = new OpenApiClient($credConfig);
+        restore_error_handler();
+
+        $this->assertSame([], $notices);
+        $this->assertNotNull($this->prop($client, '_credential'));
+        $this->assertNull($this->prop($client, '_suffix'));
+        $this->assertNull($this->prop($client, '_protocol'));
+        $this->assertNull($this->prop($client, '_endpoint'));
+    }
+
+    public function testConstructWithOpenApiConfigPreservesValues()
+    {
+        $config = new Config([
+            'accessKeyId' => 'ak-reg',
+            'accessKeySecret' => 'sk-reg',
+            'endpoint' => 'green.cn-shanghai.aliyuncs.com',
+            'regionId' => 'cn-shanghai',
+            'protocol' => 'https',
+            'method' => 'POST',
+            'userAgent' => 'unit-test-ua',
+        ]);
+        $client = new OpenApiClient($config);
+
+        $this->assertSame('green.cn-shanghai.aliyuncs.com', $this->prop($client, '_endpoint'));
+        $this->assertSame('cn-shanghai', $this->prop($client, '_regionId'));
+        $this->assertSame('https', $this->prop($client, '_protocol'));
+        $this->assertSame('POST', $this->prop($client, '_method'));
+        $this->assertSame('unit-test-ua', $this->prop($client, '_userAgent'));
+        $this->assertNull($this->prop($client, '_suffix'));
+        $this->assertNull($this->prop($client, '_httpProxy'));
+        $this->assertNotNull($this->prop($client, '_credential'));
+    }
+
+    public function testConstructStsAndBearerBranches()
+    {
+        $sts = new Config([
+            'accessKeyId' => 'ak',
+            'accessKeySecret' => 'sk',
+            'securityToken' => 'token',
+            'endpoint' => 'example.com',
+        ]);
+        $clientSts = new OpenApiClient($sts);
+        $this->assertNotNull($this->prop($clientSts, '_credential'));
+
+        $bearer = new Config([
+            'bearerToken' => 'btoken',
+            'endpoint' => 'example.com',
+        ]);
+        $clientBearer = new OpenApiClient($bearer);
+        $this->assertNotNull($this->prop($clientBearer, '_credential'));
+
+        $creConfig = new CredentialConfig([
+            'accessKeyId' => 'ak2',
+            'accessKeySecret' => 'sk2',
+            'type' => 'access_key',
+        ]);
+        $credential = new Credential($creConfig);
+        $withCred = new Config([
+            'credential' => $credential,
+            'endpoint' => 'example.com',
+        ]);
+        $clientCred = new OpenApiClient($withCred);
+        $this->assertSame($credential, $this->prop($clientCred, '_credential'));
+    }
+
+    public function testCheckConfigWithMissingEndpointPropertyDoesNotNotice()
+    {
+        $notices = [];
+        set_error_handler(function ($errno, $errstr) use (&$notices) {
+            if (stripos($errstr, 'Undefined property') !== false) {
+                $notices[] = $errstr;
+            }
+            return true;
+        });
+
+        $config = new Config([
+            'accessKeyId' => 'ak',
+            'accessKeySecret' => 'sk',
+            'endpoint' => 'ok.example.com',
+        ]);
+        $client = new OpenApiClient($config);
+        $client->checkConfig($config);
+
+        $credOnly = new CredentialConfig([
+            'type' => 'access_key',
+            'accessKeyId' => 'ak',
+            'accessKeySecret' => 'sk',
+        ]);
+        $client2 = new OpenApiClient($credOnly);
+        $client2->checkConfig($credOnly);
+        restore_error_handler();
+
+        $this->assertSame([], $notices);
+    }
+
+    public function testCheckConfigThrowsWhenEndpointNullOnOpenApiConfig()
+    {
+        $config = new Config([
+            'accessKeyId' => 'ak',
+            'accessKeySecret' => 'sk',
+        ]);
+        $config->endpoint = null;
+        $client = new OpenApiClient($config);
+        $thrown = false;
+        try {
+            $client->checkConfig($config);
+        } catch (\Throwable $e) {
+            // ClientException historically requires statusCode; either ClientException
+            // or the ctor Error proves we entered the ParameterMissing throw branch.
+            $thrown = true;
+            $this->assertTrue(
+                ($e instanceof ClientException)
+                || (stripos($e->getMessage(), 'statusCode') !== false)
+                || (stripos($e->getMessage(), 'endpoint') !== false)
+            );
+        }
+        $this->assertTrue($thrown);
+    }
+}

--- a/tests/SafeConfigPropertyTest.php
+++ b/tests/SafeConfigPropertyTest.php
@@ -145,9 +145,10 @@ class SafeConfigPropertyTest extends TestCase
         $thrown = false;
         try {
             $client->checkConfig($config);
-        } catch (\Throwable $e) {
-            // ClientException historically requires statusCode; either ClientException
-            // or the ctor Error proves we entered the ParameterMissing throw branch.
+        } catch (\Exception $e) {
+            // PHP 5.6 has no Throwable. ClientException historically requires
+            // statusCode; either ClientException or the ctor Error proves we
+            // entered the ParameterMissing throw branch.
             $thrown = true;
             $this->assertTrue(
                 ($e instanceof ClientException)


### PR DESCRIPTION
## Summary
- Guard `OpenApiClient::__construct` / `checkConfig` with `property_exists` for PHP 8+ Undefined property notices when config is partial or wrong-typed.
- PHP 5.5+ compatible; adds `SafeConfigPropertyTest`.